### PR TITLE
chore: add Docker image build + semver release pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+.gitignore
+Dockerfile
+.dockerignore
+nginx.conf
+Makefile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release
+
+# Cuts a new semver image tag whenever a PR is merged to master, based on a
+# prefix on the PR title:
+#   major: ...   -> vX+1.0.0
+#   minor: ...   -> vX.Y+1.0
+#   fix: ... / chore: ... -> vX.Y.Z+1
+# PRs without one of these prefixes don't trigger a release.
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version bump
+        id: bump
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          shopt -s nocasematch
+          if [[ "$TITLE" =~ ^major: ]]; then
+            level=major
+          elif [[ "$TITLE" =~ ^minor: ]]; then
+            level=minor
+          elif [[ "$TITLE" =~ ^(fix|chore): ]]; then
+            level=patch
+          else
+            level=none
+          fi
+          echo "level=$level" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next version
+        if: steps.bump.outputs.level != 'none'
+        id: version
+        run: |
+          last="$(git tag --list 'v*.*.*' | sort -V | tail -n1)"
+          last="${last:-v0.0.0}"
+          IFS='.' read -r major minor patch <<< "${last#v}"
+          case "${{ steps.bump.outputs.level }}" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+          echo "tag=v${major}.${minor}.${patch}" >> "$GITHUB_OUTPUT"
+          echo "version=${major}.${minor}.${patch}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        if: steps.bump.outputs.level != 'none'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Set up QEMU
+        if: steps.bump.outputs.level != 'none'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: steps.bump.outputs.level != 'none'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        if: steps.bump.outputs.level != 'none'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            rwejlgaard/pez.solutions:${{ steps.version.outputs.version }}
+            rwejlgaard/pez.solutions:latest
+
+      - name: Tag release
+        if: steps.bump.outputs.level != 'none'
+        run: |
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx:1.27-alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY . /usr/share/nginx/html
+
+EXPOSE 8080

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 8080;
+    listen [::]:8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a Dockerfile (nginx on 8080) and nginx.conf, mirroring the same pipeline just added to pez.sh
- Adds a release workflow: on a merged PR to master, a `major:`/`minor:`/`fix:`/`chore:` prefix on the PR title cuts the corresponding semver bump, builds multi-arch, and pushes to `rwejlgaard/pez.solutions` on Docker Hub, then tags the release
- No existing image/tags, so versioning starts from `v0.0.0`

## Before merging
This repo has no `DOCKER_USERNAME`/`DOCKER_TOKEN` secrets yet (pez.sh's aren't readable to copy over) — add them first or the build/push step will fail:

\`\`\`
gh secret set DOCKER_USERNAME -R RWejlgaard/pez.solutions
gh secret set DOCKER_TOKEN -R RWejlgaard/pez.solutions
\`\`\`

## Test plan
- [ ] Add the two secrets above
- [ ] Merging this PR (title starts with \`chore:\`) should cut \`v0.0.1\` and push \`rwejlgaard/pez.solutions:0.0.1\` + \`:latest\`