### PR TITLE
minor: fix broken docker build (nginx.conf excluded by .dockerignore)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,4 @@
 .gitignore
 Dockerfile
 .dockerignore
-nginx.conf
 Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:1.27-alpine
 
-COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY . /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+RUN rm -f /usr/share/nginx/html/nginx.conf
 
 EXPOSE 8080


### PR DESCRIPTION
## Summary
`.dockerignore` excluded `nginx.conf` entirely, so the Dockerfile's own `COPY nginx.conf /etc/nginx/conf.d/default.conf` failed at build time — this is what made the release workflow in #3 fail right after merge. Fixes it by copying the site first, then the nginx config, then removing the stray copy `COPY .` leaves in the html root.

Titled `minor:` since #3's merge never produced a tag (the build failed before the tag-push step), so this is effectively the first real release — landing at `v0.1.0`.

## Test plan
- [ ] Merging this should cut `v0.1.0` and push `rwejlgaard/pez.solutions:0.1.0` + `:latest` successfully