### PR TITLE
chore: remove Cloudflare Pages dev tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-.wrangler
 node_modules

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-debug:
-	wrangler pages dev .


### PR DESCRIPTION
## Summary
Removes the wrangler-based \`debug\` Makefile target and the \`.wrangler\` gitignore entry. The site deploys via SSH to helsinki-a (see \`.github/workflows/deploy.yml\`), not Cloudflare Pages, so this was unused leftover tooling.

## Test plan
N/A - removes dev-only tooling, no effect on deploy or release pipelines.